### PR TITLE
If host is heroku, use https

### DIFF
--- a/lib/smoke/index.js
+++ b/lib/smoke/index.js
@@ -16,7 +16,7 @@ module.exports.run = (opts) => {
 		}
 
 		if (!/https?\:\/\//.test(host)) {
-			host = 'http://' + host;
+			host = host.endsWith('.herokuapp.com') ? ('https://' + host) : ('http://' + host);
 		}
 
 		return test(configFile, host, opts.auth);


### PR DESCRIPTION
 🐿 v2.6.0

Seems a crappy way to do it, but I have no idea how the old smoke tests managed to use https for next-api