### PR TITLE
Respect https option

### DIFF
--- a/lib/smoke/index.js
+++ b/lib/smoke/index.js
@@ -16,7 +16,7 @@ module.exports.run = (opts) => {
 		}
 
 		if (!/https?\:\/\//.test(host)) {
-			host = host.endsWith('.herokuapp.com') ? ('https://' + host) : ('http://' + host);
+			host = 'http://' + host;
 		}
 
 		return test(configFile, host, opts.auth);

--- a/lib/smoke/test-page.js
+++ b/lib/smoke/test-page.js
@@ -13,6 +13,11 @@ class TestPage {
 	constructor (url, options) {
 		this.browser = null;
 		this.url = url;
+
+		if(options.https) {
+			this.url = this.url.replace('http:', 'https:');
+		}
+
 		this.requestHeaders = options.headers;
 		this.method = options.method || 'GET';
 		this.postData = options.body;

--- a/lib/smoke/test.js
+++ b/lib/smoke/test.js
@@ -25,6 +25,7 @@ const run = async (configFile, host, authenticate) => {
 
 			urlOpts.method = urlOpts.method || suiteOpts.method;
 			urlOpts.body = urlOpts.body || suiteOpts.body;
+			urlOpts.https = urlOpts.https || suiteOpts.https;
 
 			const fullUrl = `${host}${url}`;
 			const testPage = new TestPage(fullUrl, urlOpts);


### PR DESCRIPTION
 🐿 v2.6.0

So _this_ is how next-api's HTTPS worked.