### PR TITLE
Run each block of tests synchronously, and clear cookies before each …

### DIFF
--- a/lib/smoke/test-page.js
+++ b/lib/smoke/test-page.js
@@ -46,6 +46,11 @@ class TestPage {
 		this.browser = browser;
 		this.page = await this.browser.newPage();
 
+
+		//clear cookies for each page request
+		const cookies = await this.page.cookies(this.url);
+		await Promise.all(cookies.map(cookie => this.page.deleteCookie(cookie)));
+
 		if(this.check.status === 204) {
 			return;
 		}

--- a/lib/smoke/test.js
+++ b/lib/smoke/test.js
@@ -4,12 +4,9 @@ const verifyUrl = require('./verify-url');
 
 const directly = require('directly');
 
-const run = async (config, host, authenticate) => {
-	const browser = await puppeteer.launch();
-
+const runSuite = async (suiteOpts, host, authenticate, browser) => {
 	const urlTests = [];
 
-	config.forEach((suiteOpts) => {
 		Object.entries(suiteOpts.urls).forEach(async ([url, urlOpts]) => {
 
 			if (typeof urlOpts !== 'object') {
@@ -33,23 +30,32 @@ const run = async (config, host, authenticate) => {
 				verifyUrl(testPage, browser)
 			);
 		});
-	});
 
-	return directly(5, urlTests)
-		.then((results) => {
+		return directly(5, urlTests);
+};
 
-			browser.close();
-			const totalResults = {
-				urlsTested: results.length,
-				passed: results.filter(url => url.failed === 0),
-				failed: results.filter(url => url.failed > 0)
-			};
-			if(totalResults.failed.length) {
-				return Promise.reject(totalResults);
-			} else {
-				return Promise.resolve(totalResults);
-			}
-		});
+const run = async (config, host, authenticate) => {
+	const browser = await puppeteer.launch();
+
+	let results = [];
+
+	for(let suiteOpts of config) {
+		const suiteResults = await runSuite(suiteOpts, host, authenticate, browser);
+		results = results.concat(suiteResults);
+	}
+
+	browser.close();
+
+	const totalResults = {
+		urlsTested: results.length,
+		passed: results.filter(url => url.failed === 0),
+		failed: results.filter(url => url.failed > 0)
+	};
+	if(totalResults.failed.length) {
+		return Promise.reject(totalResults);
+	} else {
+		return Promise.resolve(totalResults);
+	}
 
 };
 


### PR DESCRIPTION
…request. This should fix next-signup tests, where cookies were being set/deleted and affecting other test URLs. (at the cost of slightly slower running, depending on how tests are set up).

 🐿 v2.6.0