### PR TITLE
Use lowercase headers from puppeteer

### DIFF
--- a/lib/smoke/verify-url.js
+++ b/lib/smoke/verify-url.js
@@ -31,7 +31,7 @@ const tests = {
 
 	content: async (testPage) => {
 		const headers = testPage.response.headers();
-		const isHTML = headers['Content-Type'] && headers['Content-Type'].includes('text/html');
+		const isHTML = headers['content-type'] && headers['content-type'].includes('text/html');
 
 		const content = isHTML ? await testPage.page.content() : await testPage.response.text();
 


### PR DESCRIPTION
 🐿 v2.7.0

@remybach this will hopefully fix the immediate problem! I might add an option to set what to wait for after navigation (defaults to `domcontentloaded` unless pageErrors or cssCoverage is on, where it uses `load`. All a bit arbitrary).