### PR TITLE
Allow 304 as an okay status

### DIFF
--- a/lib/smoke/checks.js
+++ b/lib/smoke/checks.js
@@ -12,7 +12,7 @@ module.exports = {
 				result: testPage.check.status === testPage.redirect.to
 			};
 		} else {
-			return { expected: testPage.check.status, actual: testPage.status, result: testPage.status === testPage.check.status };
+			return { expected: testPage.check.status, actual: testPage.status, result: testPage.status === testPage.check.status || testPage.status === 304 && testPage.check.status === 200 };
 		}
 	},
 

--- a/test/fixtures/smoke-pass.js
+++ b/test/fixtures/smoke-pass.js
@@ -2,6 +2,7 @@ module.exports = [{
 		urls: {
 			'/status/200': 200,
 			'/status/204': 204, // this will be skipped because we don't support it yet!
+			'/status/304': 200, // browsers will sometimes 304, so let's pretend like that is okay
 			'/status/404': {
 				status: 404,
 				content: '404',

--- a/test/tasks/smoke.js
+++ b/test/tasks/smoke.js
@@ -18,7 +18,7 @@ describe('Smoke Tests of the Smoke', () => {
 			});
 			return smoke.run()
 			.then((results) => {
-				expect(results.passed.length).toEqual(10);
+				expect(results.passed.length).toEqual(11);
 				expect(results.failed.length).toEqual(0);
 				done();
 			});


### PR DESCRIPTION
 🐿 v2.6.0

Now that we don't have no-store (https://github.com/Financial-Times/n-express/pull/484) some tests can return 304 instead of 200. 

This isn't an _ideal_ fix, but it kind of makes sense (a 304 is kind of okay) 😬 
