### PR TITLE
Use n-test-sessions-client instead of directly fetching the session tokens

### DIFF
--- a/lib/smoke/get-user-tokens.js
+++ b/lib/smoke/get-user-tokens.js
@@ -1,13 +1,5 @@
-const fetch = require('node-fetch');
+const testSessionsClient = require('@financial-times/n-test-sessions-client');
 
 module.exports = (userType) => {
-	let url = `${process.env.TEST_SESSIONS_URL}/${userType}?api_key=${process.env.TEST_SESSIONS_API_KEY}`;
-	return fetch(url)
-		.then((response) => {
-			if (response.ok) {
-				return response.json();
-			} else {
-				throw new Error('Couldn\'t fetch the test session token. Please check TEST_SESSIONS_URL and TEST_SESSIONS_API_KEY environment variables.');
-			}
-		});
+	return testSessionsClient[userType]();
 };

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     },
     "homepage": "https://github.com/Financial-Times/n-test#readme",
     "dependencies": {
+        "@financial-times/n-test-sessions-client": "^1.0.0-beta.1",
         "chalk": "^2.3.0",
         "commander": "^2.13.0",
         "directly": "^2.0.6",
         "inquirer": "^5.0.1",
-        "node-fetch": "^2.1.1",
         "puppeteer": "^1.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
I'm not sure n-test-sessions-client is really useful. The intention was to abstract away the logic of building the url like this:

```
`${process.env.TEST_SESSIONS_URL}/${userType}?api_key=${process.env.TEST_SESSIONS_API_KEY}`
```

Do you think we should keep this?

 🐿 v2.7.0