### PR TITLE
Fix open for https, and redirects

### DIFF
--- a/lib/smoke/open.js
+++ b/lib/smoke/open.js
@@ -21,11 +21,16 @@ module.exports = async (opts, sets) => {
 					urlOpts = { status: urlOpts };
 				}
 
+				if (!/https?\:\/\//.test(host)) {
+					host = 'http://' + host;
+				}
+
 				urlOpts.requestHeaders = Object.assign(urlOpts.headers || {}, suiteOpts.headers || {}, {});
 				urlOpts.requestHeaderPaths = urlOpts.requestHeaderPaths || suiteOpts.requestHeaderPaths || [];
 				urlOpts.method = urlOpts.method || suiteOpts.method;
 				urlOpts.body = urlOpts.body || suiteOpts.body;
 				urlOpts.user = suiteOpts.user;
+				urlOpts.https = urlOpts.https || suiteOpts.https;
 				urlOpts.breakpoint = urlOpts.breakpoint || suiteOpts.breakpoint || opts.breakpoint;
 
 				if(urlOpts.user && !host.includes('local')) {

--- a/lib/smoke/puppeteer-page.js
+++ b/lib/smoke/puppeteer-page.js
@@ -161,7 +161,7 @@ class PuppeteerPage {
 
 		// So horrible - because we have request interception turned on, I *think* this.response is sometimes null if it comes back before request.continue();
 		// If this happens, wait for the response interception to have stored it
-		if(!this.response) {
+		if(!this.response && this.check.status === 200) {
 			this.response = await this.waitForResponse();
 		}
 
@@ -186,8 +186,9 @@ class PuppeteerPage {
 	}
 
 	get status () {
+		const dehashedUrl = this.url.split('#')[0]; //TODO: parse URL properly
 		return REDIRECT_CODES.includes(this.check.status) ?
-			this.redirects[this.url].code :
+			this.redirects[dehashedUrl].code :
 			this.response.status();
 	}
 


### PR DESCRIPTION
 🐿 v2.7.0

This should fix next-retention smoke tests failing