### PR TITLE
Ignore _all_ browser errors that aren't assertion fails

### DIFF
--- a/lib/smoke/verify-url.js
+++ b/lib/smoke/verify-url.js
@@ -2,8 +2,6 @@
 const chalk = require('chalk');
 
 const verifyUrl = (testPage, browser, tests) => async () => {
-	//open the page
-	await testPage.init(browser);
 
 	let results = {
 		url: testPage.url,
@@ -14,6 +12,10 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 	};
 
 	try {
+
+		//open the page
+		await testPage.init(browser);
+
 		const checks = Object.entries(tests).map(([name, testFn]) => {
 			const expectation = testPage.check[name];
 			return (typeof expectation === 'undefined' ? Promise.resolve() : Promise.resolve(testFn(testPage)).then(result => ({ name, results: [].concat(result) })));
@@ -42,11 +44,7 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 
 	} catch(err) {
 		//Sometimes selenium times out. if so - ignore.
-		if(err.message === 'ESOCKETTIMEDOUT') {
-			console.warn(err);
-		} else {
-			throw err;
-		}
+		console.warn(err);
 	} finally {
 		await testPage.close();
 	}


### PR DESCRIPTION
 🐿 v2.7.0

Be super-lenient with error handling.

Basically if something in puppeteer/webdriver throws an error (that isn't an assertion fail), don't fail the build.