### PR TITLE
Fix global options being passed

### DIFF
--- a/lib/smoke/smoke-test.js
+++ b/lib/smoke/smoke-test.js
@@ -24,6 +24,8 @@ class SmokeTest {
 		this.configFile = path.join(process.cwd(), opts.config || 'test/smoke.js');
 		this.isInteractive = opts.interactive;
 		this.host = opts.host || 'https://local.ft.com:5050';
+		this.breakpoint = opts.breakpoint;
+		this.browsers = opts.browsers;
 		//TODO: default should be chrome, browsers will be opt-in
 
 		if (!/https?\:\/\//.test(this.host)) {


### PR DESCRIPTION
 🐿 v2.7.0

This meant that the staging app was still being tested cross browser when it shouldn't be.