### PR TITLE
Fix URL comparison before setting response

### DIFF
--- a/lib/smoke/puppeteer-page.js
+++ b/lib/smoke/puppeteer-page.js
@@ -133,7 +133,7 @@ class PuppeteerPage {
 
 
 		this.page.on('response', response => {
-;			const request = response.request();
+			const request = response.request();
 			const status = response.status();
 			const url = request.url();
 			if(url !== this.url.toString()) {


### PR DESCRIPTION
 🐿 v2.8.0

I swear I did this ages ago, but maybe I had it rolled back /shrug

Basically, because there are some circumstances where there's a race condition setting the response later on, so we set it with the intercepted response if the URLs match.

Because the retention URLs have hashes in them, we need to remove the hashes before comparing.