### PR TITLE
Dont throw error when an element cant be found

### DIFF
--- a/lib/smoke/checks.js
+++ b/lib/smoke/checks.js
@@ -55,7 +55,9 @@ module.exports = {
 					const assertion = testPage.check.elements[selector];
 					//If we're expecting an element, wait for it.
 					if(!!assertion > 0 && testPage.page && testPage.page.waitForSelector) {
-						await testPage.page.waitForSelector(selector);
+						try {
+							await testPage.page.waitForSelector(selector, { timeout: 5000 });
+						} catch (_) {}; // If we can't find the element, don't throw an error but carry on so the test fails
 					}
 
 					if(typeof assertion === 'number') {


### PR DESCRIPTION
 🐿 v2.8.0

`next-front-page` has a smoke test that looks for a myFT onboarding component. This test _should_ be failing right now, because the myFT code is throwing a JS error - BUT this little line is throwing an error because it can't find it, and we have an allowance for errors.

This change catches the error and proceeds to fail the test.

(I'll hold off merging until myFT fixes the thing)