### PR TITLE
Fix check for visible elements

### DIFF
--- a/lib/smoke/puppeteer-page.js
+++ b/lib/smoke/puppeteer-page.js
@@ -101,7 +101,7 @@ class PuppeteerPage {
 
 			// For user requests, only apply the request headers to the initial URL request, and any whitelisted paths. This is so that requests to other apps don't try and proxy to the app under test.
 			if(this.user) {
-				if(this.requestHeaderPaths.find(path => new RegExp(path).test(url))) {
+				if(interceptedRequest.isNavigationRequest()) {
 					overrides.headers = Object.assign({}, this.requestHeaders);
 				}
 			} else {
@@ -172,11 +172,10 @@ class PuppeteerPage {
 	}
 
 	async getVisibleElements (selector) {
-		return await this.page.$$eval(selector, els => els.filter(el => {
-			//Filter out elements that are not visible
-			const rect = el.getBoundingClientRect();
-			return rect.height > 0 && rect.width > 0;
-		}).length);
+		const elements = await this.page.$$(selector);
+		const boxes = await Promise.all(elements.map(el =>  el.boundingBox()));
+
+		return boxes.filter(boundingBox => boundingBox && boundingBox.height > 0 && boundingBox.width > 0).length;
 	}
 
 	async getElementText (selector) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "directly": "^2.0.6",
         "inquirer": "^5.0.1",
         "node-fetch": "^2.1.1",
-        "puppeteer": "^1.4.0",
+        "puppeteer": "^1.5.0",
         "wdio-sauce-service": "^0.4.8",
         "webdriverio": "^4.11.0"
     },


### PR DESCRIPTION
 🐿 v2.9.0
Something in puppeteer 1.5.0 broke this, so use the API methods rather than doing it in JS.