### PR TITLE
Pin puppeteer dependency to v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "directly": "^2.0.6",
         "inquirer": "^5.0.1",
         "node-fetch": "^2.1.1",
-        "puppeteer": "^1.5.0",
+        "puppeteer": "1.5.0",
         "wdio-sauce-service": "^0.4.8",
         "webdriverio": "^4.11.0"
     },


### PR DESCRIPTION
The latest release of puppeteer (v1.6.0) is causing errors in our smoke tests. We're pinning puppeteer to v1.5.0 until we can track down the cause of the issue.

Once we have n-test working with puppeteer v1.6.0, we can get back to pinning the puppeteer dependency more loosely i.e. v1.x.

 🐿 v2.10.0