### PR TITLE
Fix Jest security error coming from jsdom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ node_modules/@financial-times/n-gage/index.mk:
 unit-test:
 	export TEST_SESSIONS_URL=https://fuhn0pye67.execute-api.eu-west-1.amazonaws.com/prod; \
 	export TEST_SESSIONS_API_KEY=mock-api-key; \
-	jest test/tasks/*.js --forceExit $(if $(CI), --ci --runInBand --testResultsProcessor="jest-junit", )
+	jest test/tasks/*.js --testURL="http://localhost/" --forceExit $(if $(CI), --ci --runInBand --testResultsProcessor="jest-junit", )
 
 test: verify unit-test

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -1,0 +1,12 @@
+module.exports = {
+	files: {
+		allow: [],
+		allowOverrides: []
+	},
+	strings: {
+		deny: [],
+		denyOverrides: [
+			'nextpremium@ftqa\\.org' // README.md:302
+		]
+	}
+};


### PR DESCRIPTION
 🐿 v2.10.2


https://stackoverflow.com/questions/51554366/jest-securityerror-localstorage-is-not-available-for-opaque-origins