### PR TITLE
Test for % of viewport consisting of content

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ urls: {
 		},
 		content: (content) => {
 			return content.includes('some-text');
-	},
+		},
+		visibleContent: {
+		  contentSelector: '.headline, .image, .standfirst'
+		  threshold: 30 // % of viewport that should be visible content
+		},
 		performance: true //checks firstPaint/firstContentfulPaint against baseline. default = 2000, or can specify.
 	}
 }

--- a/lib/checks/index.js
+++ b/lib/checks/index.js
@@ -8,5 +8,6 @@ module.exports = {
 	performance: require('./performance'),
 	responseHeaders: require('./response-headers'),
 	screenshot: require('./screenshot'),
-	status: require('./status')
+	status: require('./status'),
+	visibleContent: require('./visible-content')
 };

--- a/lib/checks/visible-content.js
+++ b/lib/checks/visible-content.js
@@ -16,7 +16,7 @@ const percentageRed = (pixels) => {
 		const red = pixels[i];
 		const green = pixels[i+1];
 		const blue = pixels [i+2];
-		if( red >= (255 - DELTA) && green <=  DELTA && blue <= DELTA) {
+		if( red >= (255 - DELTA) && green <= DELTA && blue <= DELTA) {
 			totalRed++;
 		}
 	}
@@ -25,8 +25,6 @@ const percentageRed = (pixels) => {
 };
 
 module.exports = async (testPage) => {
-	const results = [];
-
 	const contentSelector = testPage.check.visibleContent.contentSelector;
 	const CONTENT_COLOR = '#ff0000';
 

--- a/lib/checks/visible-content.js
+++ b/lib/checks/visible-content.js
@@ -1,0 +1,62 @@
+// Checks how much of the viewport is content
+// Inputs: contentSelectors (array)
+// Input: Threshold
+
+const promisify = require('util').promisify;
+const getPixels = promisify(require('get-pixels'));
+
+const DELTA = 1;
+
+const percentageRed = (pixels) => {
+	//pixels is an array of [r, g, b, a, r, g, b, a....]
+	let total = 0;
+	let totalRed = 0;
+	for(let i = 0; i < pixels.length; i+=4) {
+		total++;
+		const red = pixels[i];
+		const green = pixels[i+1];
+		const blue = pixels [i+2];
+		if( red >= (255 - DELTA) && green <=  DELTA && blue <= DELTA) {
+			totalRed++;
+		}
+	}
+
+	return (totalRed / total) * 100;
+};
+
+module.exports = async (testPage) => {
+	const results = [];
+
+	const contentSelector = testPage.check.visibleContent.contentSelector;
+	const CONTENT_COLOR = '#ff0000';
+
+	//Make all the content red. Stop transitions in case anything transitions BG, and make images (and child images) transparent
+	testPage.page.addStyleTag({
+		content: `
+			${contentSelector} {
+				color: ${CONTENT_COLOR}!important;
+				background: ${CONTENT_COLOR}!important;
+				transition: none!important;
+			}
+			${contentSelector.replace(/\./g, 'img.')} {
+				filter: opacity(0)!important;
+			},
+			${contentSelector.replace(/\./g, 'img .')} {
+				filter: opacity(0)!important;
+			}
+		`
+	});
+
+	// Take a screenshot of the viewport
+	const screenshot = await testPage.page.screenshot({ path: 'tmp/diff.png'});
+
+	const pixels = await getPixels(screenshot, 'image/png');
+
+	const redAmount = parseFloat(percentageRed(pixels.data)).toFixed(2);
+
+	return {
+		expected: `At least ${testPage.check.visibleContent.threshold}% of the viewport should be actual content`,
+		actual: `${redAmount}% of the viewport is content`,
+		result: redAmount >= testPage.check.visibleContent.threshold
+	};
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "chalk": "^2.3.0",
         "commander": "^2.13.0",
         "directly": "^2.0.6",
+        "get-pixels": "^3.3.2",
         "inquirer": "^5.0.1",
         "node-fetch": "^2.1.1",
         "puppeteer": "1.9.0",


### PR DESCRIPTION
This works by setting the color/background of the content elements to red, taking a screenshot and counting the red pixels.

(Obviously relies on nothing else on the page being #ff0000 which we don't have on FT.com. Could make configurable one day if need be).

Works best if setting `waitUntil` to `networkidle2` or similar - so it waits for the ad to load.