### PR TITLE
Stop allowing an arbitrary number of errors

### DIFF
--- a/lib/smoke/smoke-test.js
+++ b/lib/smoke/smoke-test.js
@@ -14,8 +14,6 @@ const PuppeteerPage = require('./puppeteer-page');
 const WebdriverPage = require('./webdriver-page');
 const getBrowserstackConfig = require('./get-browserstack-config');
 
-const ERROR_THRESHOLD = 2;
-
 class SmokeTest {
 
 	constructor (options) {
@@ -140,14 +138,14 @@ class SmokeTest {
 		console.log(chalk`{bgGreen Passed:} ${totalResults.passed.length}`);
 		console.log(chalk`{bgRed Failed:} ${totalResults.failed.length}`);
 		console.log(chalk`{bgRedBright Missed:} ${totalResults.missed}`);
-		console.log(chalk`{bgMagentaBright Errors:} ${totalResults.errors.length} (threshold: ${ERROR_THRESHOLD})`);
+		console.log(chalk`{bgMagentaBright Errors:} ${totalResults.errors.length}`);
 		console.log(chalk`{bgYellowBright Time Taken:} ${timeTaken}s`);
 		console.log('--------------------------------');
 
 
 		const shouldReject = [
 			totalResults.failed.length > 0, // Tests failed
-			totalResults.errors.length > ERROR_THRESHOLD, // The amount of errors exceeded the threshold
+			totalResults.errors.length > 0,
 			totalResults.missed > 0 // Some tests were not run
 		].some(item => !!item);
 

--- a/test/tasks/smoke.test.js
+++ b/test/tasks/smoke.test.js
@@ -47,22 +47,7 @@ describe('Smoke Tests of the Smoke', () => {
 
 	describe('Tests that error', () => {
 
-		test('should handle non-assertion errors gracefully beyond a threshold', (done) => {
-			const smoke = new SmokeTest({
-				host: 'http://localhost:3004',
-				config: 'test/fixtures/smoke-error-pass.js'
-			});
-
-			return smoke.run()
-				.then((results) => {
-					expect(results.errors.length).toEqual(2);
-					expect(results.failed.length).toEqual(0);
-					expect(results.passed.length).toEqual(2);
-					done();
-				});
-		});
-
-		test('should fail if more than 2 tests error', (done) => {
+		test('should fail if any tests error', (done) => {
 			const smoke = new SmokeTest({
 				host: 'http://localhost:3004',
 				config: 'test/fixtures/smoke-error-fail.js'


### PR DESCRIPTION
 🐿 v2.10.3

This was introduced initially to allow for random puppeter/browserstack flakiness.

In hindsight, it was a terrible idea - and masks actual problems (particularly where there may only be one or two tests). This PR removes this threshold. It _may_ cause some builds to fail - but we should fix the underlying problems, or be more specific about catching flaky errors.