### PR TITLE
fixes / handle when there is no 'testPage.redirect' passed to checks.status

### DIFF
--- a/lib/checks/status.js
+++ b/lib/checks/status.js
@@ -3,12 +3,11 @@ module.exports = (testPage) => {
 		//eslint-disable-next-line no-console
 		console.info('204 status checks are not supported yet!');
 		return { expected: 204, actual: '¯\_(ツ)_/¯ ', result: true };
-		return true;
 	} else if (typeof testPage.check.status === 'string') {
 		return {
 			expected: `redirect to ${testPage.check.status}`,
-			actual: `redirect to ${testPage.redirect.to}`,
-			result: testPage.check.status === testPage.redirect.to
+			actual: testPage.redirect ? `redirect to ${testPage.redirect.to}` : 'page did not redirect',
+			result: testPage.redirect && testPage.check.status === testPage.redirect.to
 		};
 	} else {
 		return { expected: testPage.check.status, actual: testPage.status, result: testPage.status === testPage.check.status || testPage.status === 304 && testPage.check.status === 200 };


### PR DESCRIPTION
# Fixes - *handle when there is no 'testPage.redirect' passed to checks.status*

## What
Handles when there is no `testPage.redirect` passed to checks.status which was just erroring previously.

 🐿 v2.10.3