### PR TITLE
Update failure message when redirect didn't happen

### DIFF
--- a/lib/checks/status.js
+++ b/lib/checks/status.js
@@ -6,7 +6,7 @@ module.exports = (testPage) => {
 	} else if (typeof testPage.check.status === 'string') {
 		return {
 			expected: `redirect to ${testPage.check.status}`,
-			actual: testPage.redirect ? `redirect to ${testPage.redirect.to}` : 'page did not redirect',
+			actual: testPage.redirect ? `redirect to ${testPage.redirect.to}` : `did not redirect: ${testPage.status}`,
 			result: testPage.redirect && testPage.check.status === testPage.redirect.to
 		};
 	} else {


### PR DESCRIPTION
Update failure message when redirect didn't happen to include page status code

 🐿 v2.10.3