### PR TITLE
Reinstate Safari tests

### DIFF
--- a/lib/smoke/setup-page.js
+++ b/lib/smoke/setup-page.js
@@ -20,8 +20,7 @@ module.exports = (path, urlOpts, suiteOpts, globalOpts) => {
 	options.breakpoint = urlOpts.breakpoint || suiteOpts.breakpoint || globalOpts.breakpoint;
 
 	const browsers = urlOpts.browsers || suiteOpts.browsers;
-	const enabledBrowsers = globalOpts.browsers || ['chrome', 'firefox', 'internet explorer', 'MicrosoftEdge'];
-	// const enabledBrowsers = globalOpts.browsers || ['chrome', 'firefox', 'safari', 'internet explorer', 'MicrosoftEdge'];
+	const enabledBrowsers = globalOpts.browsers || ['chrome', 'firefox', 'safari', 'internet explorer', 'MicrosoftEdge'];
 
 	options.browsersToRun = ['chrome'];
 	if(Array.isArray(browsers)) {


### PR DESCRIPTION
I asked Browserstack Support and it looks they had a problem on that 6/02/19:

> Abhishek M (BrowserStack Support)
> Feb 7, 23:08 IST
> Hi Carles,
> We were certainly seeing some unexpected behavior of "Browser Start-Up failure" on 6th February on Safari. Having said that, the team has already deployed a constructive fix on 6th February itself. 
Could you please execute a few sample tests and share the session ID if you continue to see the exception. Please refer ViewSessionID.png for additional reference.
> Regards
> Abhishek M

I am going to follow their instructions here. 