### PR TITLE
Replace ft.yml with CODEOWNERS file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ references:
 
   npm_cache_keys: &npm_cache_keys
     keys:
-        - v2-dependency-npm-{{ checksum "package.json" }}-
-        - v2-dependency-npm-{{ checksum "package.json" }}
-        - v2-dependency-npm-
+        - v3-dependency-npm-{{ checksum "package.json" }}-
+        - v3-dependency-npm-{{ checksum "package.json" }}
+        - v3-dependency-npm-
 
   cache_npm_cache: &cache_npm_cache
     save_cache:
-        key: v2-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
+        key: v3-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
         paths:
         - ./node_modules/
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# See https://help.github.com/articles/about-codeowners/ for more information about this file.
+
+* arjun.gadhia@ft.com

--- a/ft.yml
+++ b/ft.yml
@@ -1,3 +1,0 @@
-owner:
-  github: adgad
-  email: arjun.gadhia@ft.com

--- a/package.json
+++ b/package.json
@@ -1,42 +1,42 @@
 {
-    "name": "@financial-times/n-test",
-    "version": "0.0.0",
-    "description": "A node module containing a collection of test tasks and utilities for Next applications",
-    "main": "index.js",
-    "bin": {
-        "n-test": "./bin/n-test.js"
-    },
-    "scripts": {
-        "test": "make test",
-        "precommit": "node_modules/.bin/secret-squirrel",
-        "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
-        "prepush": "make verify -j3"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/Financial-Times/n-test.git"
-    },
-    "author": "",
-    "license": "ISC",
-    "bugs": {
-        "url": "https://github.com/Financial-Times/n-test/issues"
-    },
-    "homepage": "https://github.com/Financial-Times/n-test#readme",
-    "dependencies": {
-        "chalk": "^2.3.0",
-        "commander": "^2.13.0",
-        "directly": "^2.0.6",
-        "get-pixels": "^3.3.2",
-        "inquirer": "^5.0.1",
-        "node-fetch": "^2.1.1",
-        "puppeteer": "1.9.0",
-        "webdriverio": "^4.11.0"
-    },
-    "devDependencies": {
-        "@financial-times/n-gage": "^2.0.1",
-        "cookie-parser": "^1.4.3",
-        "express": "^4.16.2",
-        "jest": "^22.0.6",
-        "jest-junit": "^5.1.0"
-    }
+  "name": "@financial-times/n-test",
+  "version": "0.0.0",
+  "description": "A node module containing a collection of test tasks and utilities for Next applications",
+  "main": "index.js",
+  "bin": {
+    "n-test": "./bin/n-test.js"
+  },
+  "scripts": {
+    "test": "make test",
+    "precommit": "node_modules/.bin/secret-squirrel",
+    "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
+    "prepush": "make verify -j3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Financial-Times/n-test.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/Financial-Times/n-test/issues"
+  },
+  "homepage": "https://github.com/Financial-Times/n-test#readme",
+  "dependencies": {
+    "chalk": "^2.3.0",
+    "commander": "^2.13.0",
+    "directly": "^2.0.6",
+    "get-pixels": "^3.3.2",
+    "inquirer": "^5.0.1",
+    "node-fetch": "^2.1.1",
+    "puppeteer": "1.9.0",
+    "webdriverio": "^4.11.0"
+  },
+  "devDependencies": {
+    "@financial-times/n-gage": "3.4.0",
+    "cookie-parser": "^1.4.3",
+    "express": "^4.16.2",
+    "jest": "^22.0.6",
+    "jest-junit": "^5.1.0"
+  }
 }


### PR DESCRIPTION
This PR replaces our custom `ft.yml` file with GitHub's standard CODEOWNERS file. The CODEOWNERS file defines the individual or team that is responsible for the code in the repository. Unlike `ft.yml`, code owners will automatically be asked to review any pull requests.

For more information on CODEOWNERS, see https://help.github.com/en/articles/about-code-owners.

Where a repository contains an empty `ft.yml`, no CODEOWNERS file will be created. We did this so we can easily identify which repositories are unowned by looking for the absence of a CODEOWNERS file.

The n-gage package insists that repositories have an ft.yml file. Version 3.4.0 of n-gage removes this requirement. This transformation requires n-gage version 3.4.0 in package.json because it deletes the (otherwise required) ft.yml file.
