### PR TITLE
Add timeout to webdriver page load if intended waitFor event not default

### DIFF
--- a/lib/smoke/webdriver-page.js
+++ b/lib/smoke/webdriver-page.js
@@ -17,6 +17,8 @@ class WebdriverPage {
 		this.dimensions = DIMENSIONS[options.breakpoint] || DIMENSIONS['XL'];
 		this.user = options.user || null;
 
+		this.waitUntil = options.waitUntil;
+
 		this.check = {
 			elements: options.elements,
 			screenshot: options.screenshot
@@ -27,7 +29,7 @@ class WebdriverPage {
 	async init () {
 
 		this.browserOptions = await getBrowserstackConfig(this.type);
-		if(!this.browserOptions || //skip if no environment variables
+		if (!this.browserOptions || //skip if no environment variables
 			this.isAutomatedTest && !(this.check.elements || this.check.screenshot)) {
 			return;
 		}
@@ -39,31 +41,44 @@ class WebdriverPage {
 		await this.browser.setViewportSize(this.dimensions);
 
 		//skip tests which are user based, because we can't set the FT-Test-Host header
-		if(this.method !== 'GET' || this.user) {
+		if (this.method !== 'GET' || this.user) {
 			return;
 		}
 
-		if(this.requestHeaders) {
+		if (this.requestHeaders) {
 
 			//Webdriver only lets you set cookies on the current page, so visit the page.
-			await this.browser.url(this.url.toString());
+			await this.url(this.url.toString());
 
 			//Translate request headers into cookies if we know about them
 			Object.entries(this.requestHeaders).forEach(([key, value]) => {
-				if(key.toLowerCase() === 'ft-flags') {
-					this.browser.setCookie({ name: 'next-flags', value: encodeURIComponent(value) });
+				if (key.toLowerCase() === 'ft-flags') {
+					this.browser.setCookie({name: 'next-flags', value: encodeURIComponent(value)});
 				}
 			});
 		}
 
-		return await this.browser.url(this.url.toString());
+		return await this.url(this.url.toString());
 	}
+
+	url (url) {
+		return new Promise((resolve, reject) => {
+			this.browser.url(url)
+				.then(result => {
+					setTimeout(() => {
+						resolve(result);
+					}, this.waitUntil ? 500 : 2000);
+				})
+				.catch(reject);
+		});
+	}
+
 
 	async getVisibleElements (selector) {
 		try {
 			const response = await this.browser.isVisible(selector);
 			return [].concat(response).filter(a => a).length;
-		} catch(e) {
+		} catch (e) {
 			console.log(e); //eslint-disable-line no-console
 			return null;
 		}


### PR DESCRIPTION
Add timeout to webdriver page load if intended waitFor event not default

This is to make up for the fact that chrome pages can wait for 'load' events while non-chrome can't.