### PR TITLE
Update webdriver page to use 'waitUntil' 

### DIFF
--- a/lib/smoke/puppeteer-page.js
+++ b/lib/smoke/puppeteer-page.js
@@ -199,7 +199,7 @@ class PuppeteerPage {
 	}
 
 	async getElementText (selector) {
-		return await this.page.$eval(selector, el => el.innerText);
+		return this.page.$eval(selector, el => el.innerText);
 	}
 
 	coverageFor (url) {

--- a/lib/smoke/webdriver-page.js
+++ b/lib/smoke/webdriver-page.js
@@ -22,12 +22,15 @@ class WebdriverPage {
 			screenshot: options.screenshot
 		};
 
+
+		this.waitUntil = options.waitUntil || 'domcontentloaded';
+
 	}
 
 	async init () {
 
 		this.browserOptions = await getBrowserstackConfig(this.type);
-		if(!this.browserOptions || //skip if no environment variables
+		if (!this.browserOptions || //skip if no environment variables
 			this.isAutomatedTest && !(this.check.elements || this.check.screenshot)) {
 			return;
 		}
@@ -39,42 +42,45 @@ class WebdriverPage {
 		await this.browser.setViewportSize(this.dimensions);
 
 		//skip tests which are user based, because we can't set the FT-Test-Host header
-		if(this.method !== 'GET' || this.user) {
+		if (this.method !== 'GET' || this.user) {
 			return;
 		}
 
-		if(this.requestHeaders) {
+		if (this.requestHeaders) {
 
 			//Webdriver only lets you set cookies on the current page, so visit the page.
 			await this.browser.url(this.url.toString());
 
 			//Translate request headers into cookies if we know about them
 			Object.entries(this.requestHeaders).forEach(([key, value]) => {
-				if(key.toLowerCase() === 'ft-flags') {
-					this.browser.setCookie({ name: 'next-flags', value: encodeURIComponent(value) });
+				if (key.toLowerCase() === 'ft-flags') {
+					this.browser.setCookie({name: 'next-flags', value: encodeURIComponent(value)});
 				}
 			});
 		}
 
-		return await this.browser.url(this.url.toString());
+		return this.browser.url(this.url.toString());
 	}
 
 	async getVisibleElements (selector) {
 		try {
+			if (this.waitUntil !=='domcontentloaded') {
+				await this.browser.waitUntil(() => Promise.resolve(this.browser.$(selector).isDisplayed()));
+			}
 			const response = await this.browser.isVisible(selector);
 			return [].concat(response).filter(a => a).length;
-		} catch(e) {
+		} catch (e) {
 			console.log(e); //eslint-disable-line no-console
 			return null;
 		}
 	}
 
 	async getElementText (selector) {
-		return await this.browser.getText(selector);
+		return this.browser.getText(selector);
 	}
 
 	async screenshot (fileName) {
-		return await this.browser.saveScreenshot(fileName);
+		return this.browser.saveScreenshot(fileName);
 	}
 
 	async close () {


### PR DESCRIPTION
Update webdriver page to use 'waitUntil' if pageOptions.waituntil is anything other than 'domcontentloaded'.

This is to make up for the fact that we wait for dom events such as `load` to be fired on puppeteer but not on webdriver (i.e. non-chromium)

 🐿 v2.12.4