### PR TITLE
Version-agnostic CircleCI container config references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 
 references:
 
-  container_config_node12: &container_config_node12
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
       - image: circleci/node:12-browsers
@@ -55,7 +55,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node12
+    <<: *container_config_node
     steps:
       - checkout
       - run:
@@ -85,7 +85,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node12
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -101,7 +101,7 @@ jobs:
           destination: test-results
 
   publish:
-    <<: *container_config_node12
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:


### PR DESCRIPTION
Make CircleCI container config references version-agnostic, as the references have been known to get confused with the Docker image and get updated while the actual image remains on a different version.<br/><br/>This PR was created using a nori script 🍙<br/><br/>_Nori is a command-line application for managing changes across multiple (usually Github) repositories._