### PR TITLE
CPP-442 remove reference to master 

### DIFF
--- a/lib/helpers/actions.js
+++ b/lib/helpers/actions.js
@@ -1,4 +1,4 @@
-// @adgad - ported from https://github.com/pa11y/pa11y/blob/master/lib/action.js
+// @adgad - ported from https://github.com/pa11y/pa11y/blob/HEAD/lib/action.js
 
 'use strict';
 


### PR DESCRIPTION
This PR is to remove a reference to master that was missed by nori script