### PR TITLE
Fix logging user tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ n-test allows some basic actions (e.g. clicking, interacting with forms). This h
 
 To run a test suite for a type of FT subscriber, add a `user` property to the suite and it will set the session tokens for that type of user before running the tests in that suite.
 
+For the test to get the user session tokens from [`next-test-sessions-lambda`](http://github.com/financial-times/next-test-sessions-lambda), it needs to rewrite the URL being tested to an ft.com host. The orginal URL is set in the `FT-Test-Host` header, which tells `next-router` to proxy the test URL rather than production.
+
+The test ouput will display the original URL. 
+
+*Running locally:*
+
+Ngrox will need to be installed and running on the test app's port (e.g. `./ngrok http 3002`). Tests will then need to use TEST_URL variable to specify the ngrok URL when starting the service, e.g. `make smoke TEST_URL=your_ngrok_url`. The local `next-router` needs to be running, as it will be used to proxy the test URL.
+
 *Options:* `premium`, `standard`, `expired`.
 
 *Remarks*

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To run a test suite for a type of FT subscriber, add a `user` property to the su
 
 For the test to get the user session tokens from [`next-test-sessions-lambda`](http://github.com/financial-times/next-test-sessions-lambda), it needs to rewrite the URL being tested to an ft.com host. The original URL is set in the `FT-Test-Host` header, which tells `next-router` to proxy the test URL rather than production.
 
-The test ouput will display the original URL. 
+The test output will display the original URL. 
 
 *Running locally:*
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The test output will display the original URL.
 
 *Running locally:*
 
-Ngrox will need to be installed and running on the test app's port (e.g. `./ngrok http 3002`). Tests will then need to use TEST_URL variable to specify the ngrok URL when starting the service, e.g. `make smoke TEST_URL=your_ngrok_url`. The local `next-router` needs to be running, as it will be used to proxy the test URL.
+Ngrok will need to be installed and running on the test app's port (e.g. `./ngrok http 3002`). Tests will then need to use TEST_URL variable to specify the ngrok URL when starting the service, e.g. `make smoke TEST_URL=your_ngrok_url`. The local `next-router` needs to be running, as it will be used to proxy the test URL.
 
 *Options:* `premium`, `standard`, `expired`.
 

--- a/README.md
+++ b/README.md
@@ -174,11 +174,34 @@ For the test to get the user session tokens from [`next-test-sessions-lambda`](h
 
 The test output will display the original URL. 
 
+*Options:* `premium`, `standard`, `expired`.
+
 *Running locally:*
 
-Ngrok will need to be installed and running on the test app's port (e.g. `./ngrok http 3002`). Tests will then need to use TEST_URL variable to specify the ngrok URL when starting the service, e.g. `make smoke TEST_URL=your_ngrok_url`. The local `next-router` needs to be running, as it will be used to proxy the test URL.
+Ngrok provides a secure public URL for the local test app and will need to be installed and running on the the app's port. Tests will then use the TEST_URL variable to specify the ngrok URL when starting the service. The local `next-router` needs to be running, as it will be used to proxy the test URL.
 
-*Options:* `premium`, `standard`, `expired`.
+Example steps to run next-article user tests locally:
+
+Run next-article and next-router locally:
+
+```sh
+$ cd ~/next-article
+$ make run
+$ cd ~/next-router
+4 make run
+```
+
+Run ngrok on next-article's local port:
+
+```
+$ ./ngrok http 3002
+```
+
+Run the test against the ngrok address provided (can be either http or https):
+
+```
+make smoke TEST_URL=https://05bd2344ebca.ngrok.io
+```
 
 *Remarks*
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ n-test allows some basic actions (e.g. clicking, interacting with forms). This h
 
 To run a test suite for a type of FT subscriber, add a `user` property to the suite and it will set the session tokens for that type of user before running the tests in that suite.
 
-For the test to get the user session tokens from [`next-test-sessions-lambda`](http://github.com/financial-times/next-test-sessions-lambda), it needs to rewrite the URL being tested to an ft.com host. The orginal URL is set in the `FT-Test-Host` header, which tells `next-router` to proxy the test URL rather than production.
+For the test to get the user session tokens from [`next-test-sessions-lambda`](http://github.com/financial-times/next-test-sessions-lambda), it needs to rewrite the URL being tested to an ft.com host. The original URL is set in the `FT-Test-Host` header, which tells `next-router` to proxy the test URL rather than production.
 
 The test ouput will display the original URL. 
 

--- a/lib/smoke/puppeteer-page.js
+++ b/lib/smoke/puppeteer-page.js
@@ -18,6 +18,7 @@ class PuppeteerPage {
 		this.url = options.url;
 		this.url.hash = '';
 		this.host = options.url.host;
+		this.https = options.https;
 
 		this.requestHeaders = Object.assign({}, options.requestHeaders || {});
 		this.method = options.method || 'GET';

--- a/lib/smoke/setup-page.js
+++ b/lib/smoke/setup-page.js
@@ -32,7 +32,7 @@ module.exports = (path, urlOpts, suiteOpts, globalOpts) => {
 
 	if(options.user && !host.includes('local')) {
 		options.requestHeaders['FT-Test-Host'] = host.replace('https://', '').replace('http://', '');
-		host = 'https://www.ft.com';
+		host = process.env.CI ? 'https://www.ft.com' : 'https://local.ft.com:5050'
 	} else if (options.user) {
 		//eslint-disable-next-line
 		console.warn('Cannot run user based tests on local URLs, as they rely on the FT-Test-Host. To run this locally, please use ngrok');

--- a/lib/smoke/setup-page.js
+++ b/lib/smoke/setup-page.js
@@ -32,7 +32,7 @@ module.exports = (path, urlOpts, suiteOpts, globalOpts) => {
 
 	if(options.user && !host.includes('local')) {
 		options.requestHeaders['FT-Test-Host'] = host.replace('https://', '').replace('http://', '');
-		host = process.env.CI ? 'https://www.ft.com' : 'https://local.ft.com:5050'
+		host = process.env.CI ? 'https://www.ft.com' : 'https://local.ft.com:5050';
 	} else if (options.user) {
 		//eslint-disable-next-line
 		console.warn('Cannot run user based tests on local URLs, as they rely on the FT-Test-Host. To run this locally, please use ngrok');

--- a/lib/smoke/setup-page.js
+++ b/lib/smoke/setup-page.js
@@ -16,7 +16,7 @@ module.exports = (path, urlOpts, suiteOpts, globalOpts) => {
 	options.method = urlOpts.method || suiteOpts.method;
 	options.body = urlOpts.body || suiteOpts.body;
 	options.user = suiteOpts.user;
-	options.https = urlOpts.https || suiteOpts.https;
+	options.https = urlOpts.https || suiteOpts.https || globalOpts.https;
 	options.breakpoint = urlOpts.breakpoint || suiteOpts.breakpoint || globalOpts.breakpoint;
 
 	const browsers = urlOpts.browsers || suiteOpts.browsers;

--- a/lib/smoke/smoke-test.js
+++ b/lib/smoke/smoke-test.js
@@ -24,6 +24,7 @@ class SmokeTest {
 		this.host = options.host || 'https://local.ft.com:5050';
 		this.breakpoint = options.breakpoint;
 		this.browsers = options.browsers;
+		this.https = this.host.includes('https');
 		//TODO: default should be chrome, browsers will be opt-in
 
 		if (!/https?\:\/\//.test(this.host)) {
@@ -56,7 +57,8 @@ class SmokeTest {
 			headers: this.globalHeaders,
 			browsers: this.browsers,
 			breakpoint: this.breakpoint,
-			host: this.host
+			host: this.host,
+			https: this.https
 		};
 
 		const puppetTests = [];

--- a/lib/smoke/verify-url.js
+++ b/lib/smoke/verify-url.js
@@ -32,7 +32,7 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 			realUrl = new URL(`
 				${testPage.https ? 'https://' : 'http://'}
 				${testPage.requestHeaders['FT-Test-Host']}
-				${testPage.path || ''}
+				${testPage.url.pathname || ''}
 			`);
 		}
 		console.log(chalk`{bold Testing URL }({blue ${testPage.type}}): {underline.yellow ${realUrl.href || testPage.url.toString()}}`);

--- a/lib/smoke/verify-url.js
+++ b/lib/smoke/verify-url.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 const chalk = require('chalk');
+const { URL } = require('url');
 
 const { NTestError } = require('../errors');
 
@@ -29,10 +30,13 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 		//check for user option, use real url for logging
 		let realUrl = ''
 		if (testPage.requestHeaders['FT-Test-Host']) {
-			testPage.https ? realUrl = 'https://' : realUrl = 'http://';
-			realUrl = `${realUrl}${testPage.requestHeaders['FT-Test-Host']}${testPage.path || ''}`
-		};		
+			realUrl = new URL(`
+				${testPage.https ? 'https://' : 'http://'}
+				${testPage.requestHeaders['FT-Test-Host']}
+				${testPage.path || ''}
+			`)};
 		console.log(chalk`{bold Testing URL }({blue ${testPage.type}}): {underline.yellow ${realUrl || testPage.url.toString()}}`);
+		
 		checkResults
 			.filter(result => !!result)
 			.forEach((check) => {

--- a/lib/smoke/verify-url.js
+++ b/lib/smoke/verify-url.js
@@ -24,9 +24,15 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 			return (typeof expectation === 'undefined' ? Promise.resolve() : Promise.resolve(testFn(testPage)).then(result => ({ name, results: [].concat(result) })));
 		});
 
-
 		const checkResults = await Promise.all(checks);
-		console.log(chalk`{bold Testing URL }({blue ${testPage.type}}): {underline.yellow ${testPage.url.toString()}}`);
+		
+		//check for user option, use real url for logging
+		let realUrl = ''
+		if (testPage.requestHeaders['FT-Test-Host']) {
+			testPage.https ? realUrl = 'https://' : realUrl = 'http://';
+			realUrl = `${realUrl}${testPage.requestHeaders['FT-Test-Host']}${testPage.path || ''}`
+		};		
+		console.log(chalk`{bold Testing URL }({blue ${testPage.type}}): {underline.yellow ${realUrl || testPage.url.toString()}}`);
 		checkResults
 			.filter(result => !!result)
 			.forEach((check) => {

--- a/lib/smoke/verify-url.js
+++ b/lib/smoke/verify-url.js
@@ -33,7 +33,8 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 				${testPage.https ? 'https://' : 'http://'}
 				${testPage.requestHeaders['FT-Test-Host']}
 				${testPage.path || ''}
-			`)};
+			`);
+		}
 		console.log(chalk`{bold Testing URL }({blue ${testPage.type}}): {underline.yellow ${realUrl.href || testPage.url.toString()}}`);
 		checkResults
 			.filter(result => !!result)

--- a/lib/smoke/verify-url.js
+++ b/lib/smoke/verify-url.js
@@ -35,7 +35,7 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 				${testPage.requestHeaders['FT-Test-Host']}
 				${testPage.path || ''}
 			`)};
-		console.log(chalk`{bold Testing URL }({blue ${testPage.type}}): {underline.yellow ${realUrl || testPage.url.toString()}}`);
+		console.log(chalk`{bold Testing URL }({blue ${testPage.type}}): {underline.yellow ${realUrl.href || testPage.url.toString()}}`);
 		
 		checkResults
 			.filter(result => !!result)

--- a/lib/smoke/verify-url.js
+++ b/lib/smoke/verify-url.js
@@ -27,7 +27,7 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 
 		const checkResults = await Promise.all(checks);
 		//check for user option, use real url for logging
-		let realUrl = ''
+		let realUrl = {};
 		if (testPage.requestHeaders['FT-Test-Host']) {
 			realUrl = new URL(`
 				${testPage.https ? 'https://' : 'http://'}

--- a/lib/smoke/verify-url.js
+++ b/lib/smoke/verify-url.js
@@ -26,7 +26,6 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 		});
 
 		const checkResults = await Promise.all(checks);
-		
 		//check for user option, use real url for logging
 		let realUrl = ''
 		if (testPage.requestHeaders['FT-Test-Host']) {
@@ -36,7 +35,6 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 				${testPage.path || ''}
 			`)};
 		console.log(chalk`{bold Testing URL }({blue ${testPage.type}}): {underline.yellow ${realUrl.href || testPage.url.toString()}}`);
-		
 		checkResults
 			.filter(result => !!result)
 			.forEach((check) => {


### PR DESCRIPTION
When the 'user' option is used to test logging-in behaviour, the original URL is overwritten with a .ft.com host (with the original in the FT-Test-Host header). This is necessary to obtain a user token.

Because of this, the test results print the .ft.com address rather than the original, as they're referencing 'testpage.url'.

This pull request is to check for the presence of the FT-Test-Host header, and, if it exists, print the original URL instead. This should remove any confusion when interpreting the test results.