### PR TITLE
fix: ignore certificate errors for development

### DIFF
--- a/lib/smoke/smoke-test.js
+++ b/lib/smoke/smoke-test.js
@@ -64,7 +64,7 @@ class SmokeTest {
 		const puppetTests = [];
 		const crossBrowserTests = [];
 
-		this.browser = await puppeteer.launch();
+		this.browser = await puppeteer.launch({ ignoreHTTPSErrors: process.env.NODE_ENV === 'development' });
 
 		for (let suiteOptions of configsToRun) {
 			for (let path in suiteOptions.urls) { //eslint-disable-line guard-for-in


### PR DESCRIPTION
## Description

Running the smoke tests in localhost (MacOs) is not passing due to a certificate error:

```
Error: net::ERR_CERT_AUTHORITY_INVALID at https://local.ft.com:3002/v2/schema
    at navigate (/Users/aaa/FT/next-api/node_modules/puppeteer/lib/FrameManager.js:120:37)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async FrameManager.navigateFrame (/Users/aaa/FT/next-api/node_modules/puppeteer/lib/FrameManager.js:94:17)
    at async Frame.goto (/Users/aaa/FT/next-api/node_modules/puppeteer/lib/FrameManager.js:406:12)
    at async Page.goto (/Users/aaa/FT/next-api/node_modules/puppeteer/lib/Page.js:674:12)
    at async PuppeteerPage.init (/Users/aaa/FT/next-api/node_modules/@financial-times/n-test/lib/smoke/puppeteer-page.js:168:24)
    at async /Users/aaa/FT/next-api/node_modules/@financial-times/n-test/lib/smoke/verify-url.js:21:3
```

Reading the project documentation, I found that with NODE_ENV=development the certs checking should be skipped, but that did not happen in my local environment.

I've just added this flag in the smoke tests to ignore the certificates in that scenario