### PR TITLE
Improve output for troubleshooting failed smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ module.exports = [
 		urls: {
 			'/': 200,
 			'/redirect': '/'
-		}
+		},
+		description: 'Test suite descriptions are optional',
 	}
 ];
 ```
@@ -110,7 +111,8 @@ urls: {
 		  contentSelector: '.headline, .image, .standfirst'
 		  threshold: 30 // % of viewport that should be visible content
 		},
-		performance: true //checks firstPaint/firstContentfulPaint against baseline. default = 2000, or can specify.
+		performance: true, //checks firstPaint/firstContentfulPaint against baseline. default = 2000, or can specify.
+		description: 'Each test may have an optional description. It will display when the test result is reported',
 	}
 }
 ...

--- a/lib/checks/index.js
+++ b/lib/checks/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+	status: require('./status'),
 	content: require('./content'),
 	cssCoverage: require('./css-coverage'),
 	elements: require('./elements'),
@@ -8,6 +9,5 @@ module.exports = {
 	performance: require('./performance'),
 	responseHeaders: require('./response-headers'),
 	screenshot: require('./screenshot'),
-	status: require('./status'),
 	visibleContent: require('./visible-content')
 };

--- a/lib/checks/status.js
+++ b/lib/checks/status.js
@@ -1,4 +1,16 @@
-module.exports = (testPage) => {
+const outputErrorInfo = async (testPage) => {
+	const headers = testPage.response.headers();
+	const isHTML = headers['content-Type'] && headers['content-Type'].includes('text/html');
+	const content = isHTML ? await testPage.page.content() : await testPage.response.text();
+	return `Status = ${testPage.status}. Response body content :
+
+	${content}
+
+	~ENDS~
+	`;
+};
+
+module.exports = async (testPage) => {
 	if (testPage.check.status === 204) {
 		//eslint-disable-next-line no-console
 		console.info('204 status checks are not supported yet!');
@@ -10,6 +22,11 @@ module.exports = (testPage) => {
 			result: testPage.redirect && testPage.check.status === testPage.redirect.to
 		};
 	} else {
-		return { expected: testPage.check.status, actual: testPage.status, result: testPage.status === testPage.check.status || testPage.status === 304 && testPage.check.status === 200 };
+		const isUnexpectedHttpError = testPage.check.status !== 500 && testPage.status === 500;
+		return {
+			expected: `Status = ${testPage.check.status}`,
+			actual: isUnexpectedHttpError ? await outputErrorInfo(testPage) : `Status = ${testPage.status}`,
+			result: testPage.status === testPage.check.status || testPage.status === 304 && testPage.check.status === 200
+		};
 	}
 };

--- a/lib/smoke/puppeteer-page.js
+++ b/lib/smoke/puppeteer-page.js
@@ -15,6 +15,7 @@ class PuppeteerPage {
 		this.browser = null;
 		this.type = 'Chrome';
 		this.name = options.name;
+		this.description = options.description || '';
 		this.url = options.url;
 		this.url.hash = '';
 		this.host = options.url.host;

--- a/lib/smoke/setup-page.js
+++ b/lib/smoke/setup-page.js
@@ -10,6 +10,10 @@ module.exports = (path, urlOpts, suiteOpts, globalOpts) => {
 
 	options.name = suiteOpts.name;
 
+	// description=false prevents the test suite description
+	// cascading down to the individual test.
+	options.description = urlOpts.description !== false && [suiteOpts.description, urlOpts.description].filter(Boolean).join('. ');
+
 	options.requestHeaders = Object.assign({}, globalOpts.headers || {}, suiteOpts.headers || {}, urlOpts.headers || {});
 	options.requestHeaderPaths = urlOpts.requestHeaderPaths || suiteOpts.requestHeaderPaths || [];
 

--- a/lib/smoke/verify-url.js
+++ b/lib/smoke/verify-url.js
@@ -35,7 +35,7 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 				${testPage.url.pathname || ''}
 			`);
 		}
-		const description = testPage.description? `\n\tDescription: ${testPage.description}` : '';
+		const description = testPage.description? chalk`\n\t{bold Description:} ${testPage.description}` : '';
 		console.log(chalk`{bold Testing URL }({blue ${testPage.type}}): {underline.yellow ${realUrl.href || testPage.url.toString()}}${description}`);
 		checkResults
 			.filter(result => !!result)

--- a/lib/smoke/verify-url.js
+++ b/lib/smoke/verify-url.js
@@ -35,7 +35,8 @@ const verifyUrl = (testPage, browser, tests) => async () => {
 				${testPage.url.pathname || ''}
 			`);
 		}
-		console.log(chalk`{bold Testing URL }({blue ${testPage.type}}): {underline.yellow ${realUrl.href || testPage.url.toString()}}`);
+		const description = testPage.description? `\n\tDescription: ${testPage.description}` : '';
+		console.log(chalk`{bold Testing URL }({blue ${testPage.type}}): {underline.yellow ${realUrl.href || testPage.url.toString()}}${description}`);
 		checkResults
 			.filter(result => !!result)
 			.forEach((check) => {

--- a/lib/smoke/webdriver-page.js
+++ b/lib/smoke/webdriver-page.js
@@ -8,6 +8,7 @@ class WebdriverPage {
 	constructor (options, browserName, isAutomatedTest) {
 		this.type = browserName;
 		this.url = options.url;
+		this.description = options.description || '';
 
 		this.isAutomatedTest = isAutomatedTest;
 

--- a/test/fixtures/smoke-fail.js
+++ b/test/fixtures/smoke-fail.js
@@ -3,8 +3,13 @@ const assert = require('assert');
 module.exports = [{
 	urls: {
 		'/status/503': 200,
+		'/status/200': 500,
 		'/status/404': {
 			status: 404
+		},
+		'/status/html/500': {
+			description: 'Output should show HTML response body when unexpected status code',
+			status: 200,
 		},
 		'/coverage/bad': {
 			cssCoverage: {
@@ -25,7 +30,7 @@ module.exports = [{
 		},
 		'/json': {
 			content: (body) => {
-				assert.equal(body.key, 'wrong-value');
+				assert.strictEqual(body.key, 'wrong-value');
 			}
 		}
 	}

--- a/test/server/app.js
+++ b/test/server/app.js
@@ -6,6 +6,24 @@ app.get('/status/:status', (req, res) => {
 	res.status(req.params.status).send(req.params.status);
 });
 
+app.get('/status/html/:status', (req, res) => {
+	res
+		.status(req.params.status)
+		.set('Content-Type', 'text/html')
+		.send(`
+			<!DOCTYPE html>
+			<html lang="en">
+				<head>
+				<meta charset="utf-8">
+				<title>Status ${req.params.status}</title>
+				</head>
+				<body>
+					<h1>Status is ${req.params.status}</h1>
+				</body>
+			</html>
+		`);
+});
+
 app.get('/coverage/good', (req, res) => {
 	res.send(`
 		<body>

--- a/test/tasks/smoke.test.js
+++ b/test/tasks/smoke.test.js
@@ -37,7 +37,7 @@ describe('Smoke Tests of the Smoke', () => {
 			return smoke.run()
 				.catch((results) => {
 					expect(results.passed.length).toEqual(1);
-					expect(results.failed.length).toEqual(5);
+					expect(results.failed.length).toEqual(7);
 					expect(results.errors.length).toEqual(0);
 					done();
 				});


### PR DESCRIPTION
I've been repeatedly seeing broken builds due to some some flakey smoke tests so I've made a few minor improvements to make it easier to see the cause. The three individual commits in this PR:

* [`8d04f63`](https://github.com/Financial-Times/n-test/commit/8d04f63d538529281b94ef3e472a724027910412): adds a description field to smoke tests and smoke test suites.
* [`5bcc556`](https://github.com/Financial-Times/n-test/commit/5bcc556eb5667f2d0554763a99b84a5f0d06e3a0): moves the status check to be first. Usually none of the test's other check will make any sense if the status code is wrong and it's often buried in a list of checks. 
* [`afb6bb6`](https://github.com/Financial-Times/n-test/pull/172/commits/afb6bb625da8674efb9879504a7d7109f95c7818): shows the error response body in the console. You can often tell a fair bit from the error message!
