### PR TITLE
CPP-642 migrate from circleci/* to cimg/*

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
   container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:12-browsers
+      - image: cimg/node:12.22-browsers
 
   workspace_root: &workspace_root
     ~/project


### PR DESCRIPTION
These images will be EOL from Dec 31st, and we should migrate to the modern cimg/* equivalents.