### PR TITLE
CI-1224 - Allow launch options/args to be passed in from running applications

### DIFF
--- a/lib/smoke/smoke-test.js
+++ b/lib/smoke/smoke-test.js
@@ -25,6 +25,7 @@ class SmokeTest {
 		this.breakpoint = options.breakpoint;
 		this.browsers = options.browsers;
 		this.https = this.host.includes('https');
+		this.launchOptions = options.launchOptions || {};
 		//TODO: default should be chrome, browsers will be opt-in
 
 		if (!/https?\:\/\//.test(this.host)) {
@@ -64,7 +65,7 @@ class SmokeTest {
 		const puppetTests = [];
 		const crossBrowserTests = [];
 
-		this.browser = await puppeteer.launch();
+		this.browser = await puppeteer.launch(this.launchOptions);
 
 		for (let suiteOptions of configsToRun) {
 			for (let path in suiteOptions.urls) { //eslint-disable-line guard-for-in


### PR DESCRIPTION
This allows consuming applications to set puppeteer launch args along with other options when running through toolkit.