### PR TITLE
Add Node 20 support and drop Node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,13 @@ orbs:
 executors:
   node:
     docker:
-      - image: cimg/node:18.16-browsers
+      - image: cimg/node:20.11
+  node18_16:
+    docker:
+      - image: cimg/node:18.16
+  node16_20:
+    docker:
+      - image: cimg/node:16.20
 jobs:
   checkout:
     docker:
@@ -40,6 +46,8 @@ workflows:
             parameters:
               executor:
                 - node
+                - node18_16
+                - node16_20
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
@@ -51,6 +59,8 @@ workflows:
             parameters:
               executor:
                 - node
+                - node18_16
+                - node16_20
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
@@ -62,6 +72,8 @@ workflows:
             parameters:
               executor:
                 - node
+                - node18_16
+                - node16_20
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
@@ -95,6 +107,8 @@ workflows:
             parameters:
               executor:
                 - node
+                - node18_16
+                - node16_20
       - tool-kit/build:
           name: tool-kit/build-<< matrix.executor >>
           requires:
@@ -103,6 +117,8 @@ workflows:
             parameters:
               executor:
                 - node
+                - node18_16
+                - node16_20
       - tool-kit/test:
           name: tool-kit/test-<< matrix.executor >>
           requires:
@@ -111,3 +127,5 @@ workflows:
             parameters:
               executor:
                 - node
+                - node18_16
+                - node16_20

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,6 @@ executors:
   node18_16:
     docker:
       - image: cimg/node:18.16
-  node16_20:
-    docker:
-      - image: cimg/node:16.20
 jobs:
   checkout:
     docker:
@@ -47,7 +44,6 @@ workflows:
               executor:
                 - node
                 - node18_16
-                - node16_20
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
@@ -60,7 +56,6 @@ workflows:
               executor:
                 - node
                 - node18_16
-                - node16_20
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
@@ -73,7 +68,6 @@ workflows:
               executor:
                 - node
                 - node18_16
-                - node16_20
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
@@ -108,7 +102,6 @@ workflows:
               executor:
                 - node
                 - node18_16
-                - node16_20
       - tool-kit/build:
           name: tool-kit/build-<< matrix.executor >>
           requires:
@@ -118,7 +111,6 @@ workflows:
               executor:
                 - node
                 - node18_16
-                - node16_20
       - tool-kit/test:
           name: tool-kit/test-<< matrix.executor >>
           requires:
@@ -128,4 +120,3 @@ workflows:
               executor:
                 - node
                 - node18_16
-                - node16_20

--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -4,4 +4,7 @@ plugins:
 hooks: {}
 options:
   "@dotcom-tool-kit/circleci":
-    nodeVersion: "18.16-browsers"
+    nodeVersion:
+      - "20.11"
+      - "18.16"
+      - "16.20"

--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -7,4 +7,3 @@ options:
     nodeVersion:
       - "20.11"
       - "18.16"
-      - "16.20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,8 @@
         "snyk": "^1.168.0"
       },
       "engines": {
-        "node": "16.x || 18.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x || 10.x"
       }
     },
     "node_modules/@actions/exec": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,8 @@
         "snyk": "^1.168.0"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       }
     },
     "node_modules/@actions/exec": {

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "@dotcom-tool-kit/jest": "^3.4.0"
   },
   "engines": {
-    "node": "16.x || 18.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "16.x || 18.x || 20.x",
+    "npm": "7.x || 8.x || 9.x || 10.x"
   },
   "volta": {
-    "node": "18.16.0"
+    "node": "20.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "@dotcom-tool-kit/jest": "^3.4.0"
   },
   "engines": {
-    "node": "16.x || 18.x || 20.x",
-    "npm": "7.x || 8.x || 9.x || 10.x"
+    "node": "18.x || 20.x",
+    "npm": "8.x || 9.x || 10.x"
   },
   "volta": {
     "node": "20.11.0"


### PR DESCRIPTION
Whilst there are a couple of potential breaking changes in the pipeline (#203 and #205) - lets add support for Node 20 and remove support for Node 16.